### PR TITLE
fix: Use Gunicorn for production deployment instead of Django runserver

### DIFF
--- a/backend/djangocfw/entrypoint.sh
+++ b/backend/djangocfw/entrypoint.sh
@@ -34,4 +34,10 @@ python manage.py create_template_project
 
 # Start server
 echo "Starting server..."
-python manage.py runserver 0.0.0.0:8000 
+if [ "$DJANGO_DEBUG" = "False" ] || [ "$DJANGO_DEBUG" = "false" ]; then
+    echo "Production mode: starting with Gunicorn"
+    exec gunicorn djangocfw.wsgi:application --bind 0.0.0.0:8000 --workers 3
+else
+    echo "Development mode: starting with runserver"
+    exec python manage.py runserver 0.0.0.0:8000
+fi 


### PR DESCRIPTION
## Summary
- Switch from Django development server to Gunicorn in production deployment
- Fix production server warning by checking DJANGO_DEBUG environment variable
- Maintain development server for local development while using Gunicorn in production

## Test plan
- [ ] Deploy to production and verify Gunicorn is used instead of runserver
- [ ] Confirm production warning is eliminated
- [ ] Verify application functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)