### PR TITLE
fix: Add gunicorn to requirements.txt for production deployment

### DIFF
--- a/backend/djangocfw/requirements.txt
+++ b/backend/djangocfw/requirements.txt
@@ -14,6 +14,7 @@ shapely
 loguru
 requests
 daphne 
+gunicorn
 debugpy==1.5.1
 pyproj==3.6.1
 whitenoise==6.6.0


### PR DESCRIPTION
## Summary
- Add missing gunicorn dependency to requirements.txt
- Fixes "gunicorn: not found" error in production deployment
- Required for production server functionality

## Test plan
- [ ] Deploy and verify gunicorn starts successfully in production
- [ ] Confirm no "gunicorn: not found" errors

🤖 Generated with [Claude Code](https://claude.ai/code)